### PR TITLE
Add missing dependency: stream-to-array

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,44 @@
 {
   "name": "strapi-provider-upload-multiple-provider",
-  "version": "1.0.0",
+  "version": "1.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "1.0.0",
-      "license": "ISC"
+      "name": "strapi-provider-upload-multiple-provider",
+      "version": "1.0.4",
+      "license": "ISC",
+      "dependencies": {
+        "stream-to-array": "^2.3.0"
+      }
+    },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="
+    },
+    "node_modules/stream-to-array": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/stream-to-array/-/stream-to-array-2.3.0.tgz",
+      "integrity": "sha512-UsZtOYEn4tWU2RGLOXr/o/xjRBftZRlG3dEWoaHr8j4GuypJ3isitGbVyjQKAuMu+xbiop8q224TjiZWc4XTZA==",
+      "dependencies": {
+        "any-promise": "^1.1.0"
+      }
+    }
+  },
+  "dependencies": {
+    "any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="
+    },
+    "stream-to-array": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/stream-to-array/-/stream-to-array-2.3.0.tgz",
+      "integrity": "sha512-UsZtOYEn4tWU2RGLOXr/o/xjRBftZRlG3dEWoaHr8j4GuypJ3isitGbVyjQKAuMu+xbiop8q224TjiZWc4XTZA==",
+      "requires": {
+        "any-promise": "^1.1.0"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,5 +20,8 @@
   "bugs": {
     "url": "https://github.com/jimrowetpa/strapi-provider-upload-multiple-provider/issues"
   },
-  "homepage": "https://github.com/jimrowetpa/strapi-provider-upload-multiple-provider#readme"
+  "homepage": "https://github.com/jimrowetpa/strapi-provider-upload-multiple-provider#readme",
+  "dependencies": {
+    "stream-to-array": "^2.3.0"
+  }
 }


### PR DESCRIPTION
Without this, it will complain about a missing dependency during build.

I assume, your project already uses this dependency and thus it didn't complain?